### PR TITLE
[CROSSDATA-940] Removed describe as resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Pending changelog
 * Removed catalog as resource
 * Added database as resource
+* Removed Describe as action. Now Read is enough to read metadata.
 
 ## 0.1.0 (November 21, 2016)
 

--- a/src/main/scala/com/stratio/crossdata/security/Action.scala
+++ b/src/main/scala/com/stratio/crossdata/security/Action.scala
@@ -28,6 +28,4 @@ case object Create extends Action
 
 case object Drop extends Action
 
-case object Describe extends Action
-
 case object Cache extends Action


### PR DESCRIPTION
Removed describe. Now read permission is enough to perform describe queries.